### PR TITLE
Feature/support subscription

### DIFF
--- a/solon-integration-projects/solon-plugin-auth/jap-ids-solon-plugin/src/test/resources/WEB-INF/view/index.html
+++ b/solon-integration-projects/solon-plugin-auth/jap-ids-solon-plugin/src/test/resources/WEB-INF/view/index.html
@@ -67,7 +67,7 @@
 <h2>可供选择的 client 信息</h2>
 <table class="table" border="1">
   <tr>
-    <th width="110">demo.App Name</th>
+    <th width="110">App Name</th>
     <th width="250">Client ID</th>
     <th width="330">Client Secret</th>
     <th width="134">Redirect Uri</th>

--- a/solon-integration-projects/solon-plugin-auth/jap-ids-solon-plugin/src/test/resources/WEB-INF/view/index.html
+++ b/solon-integration-projects/solon-plugin-auth/jap-ids-solon-plugin/src/test/resources/WEB-INF/view/index.html
@@ -67,7 +67,7 @@
 <h2>可供选择的 client 信息</h2>
 <table class="table" border="1">
   <tr>
-    <th width="110">App Name</th>
+    <th width="110">demo.App Name</th>
     <th width="250">Client ID</th>
     <th width="330">Client Secret</th>
     <th width="134">Redirect Uri</th>

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
@@ -67,7 +67,13 @@
 
         <dependency>
             <groupId>org.noear</groupId>
+            <artifactId>solon.net</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
             <artifactId>solon.boot.smarthttp</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
@@ -20,11 +20,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.noear</groupId>
-            <artifactId>solon</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
             <version>${graphql-java.version}</version>
@@ -43,12 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.noear</groupId>
-            <artifactId>solon.view.thymeleaf</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>
@@ -64,6 +53,34 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
             <version>${reactor.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>snack3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon.boot.smarthttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>socketd</artifactId>
+            <version>${socketd.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon.view.thymeleaf</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/GraphqlPlugin.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/GraphqlPlugin.java
@@ -6,6 +6,8 @@ import graphql.solon.annotation.QueryMapping;
 import graphql.solon.annotation.QueryMappingAnnoHandler;
 import graphql.solon.annotation.SchemaMapping;
 import graphql.solon.annotation.SchemaMappingAnnoHandler;
+import graphql.solon.annotation.SubscriptionMapping;
+import graphql.solon.annotation.SubscriptionMappingAnnoHandler;
 import graphql.solon.config.GraphqlConfiguration;
 import graphql.solon.controller.GraphiqlController;
 import graphql.solon.controller.GraphqlController;
@@ -17,6 +19,7 @@ import graphql.solon.execution.DefaultBatchLoaderRegistry;
 import graphql.solon.properties.GraphqlProperties;
 import graphql.solon.resolver.argument.HandlerMethodArgumentResolver;
 import graphql.solon.resolver.argument.HandlerMethodArgumentResolverCollect;
+import graphql.solon.ws.GraphqlWebsocket;
 import org.noear.solon.core.AppContext;
 import org.noear.solon.core.Plugin;
 import org.noear.solon.core.event.AppLoadEndEvent;
@@ -54,9 +57,14 @@ public class GraphqlPlugin implements Plugin {
         BatchMappingAnnoHandler batchMappingExtractor = new BatchMappingAnnoHandler(context);
         context.beanExtractorAdd(BatchMapping.class, batchMappingExtractor);
 
+        SubscriptionMappingAnnoHandler subscriptionMappingAnnoHandler = new SubscriptionMappingAnnoHandler(
+            context);
+        context.beanExtractorAdd(SubscriptionMapping.class, subscriptionMappingAnnoHandler);
+
         context.wrapAndPut(QueryMappingAnnoHandler.class, queryExtractor);
         context.wrapAndPut(SchemaMappingAnnoHandler.class, schemaExtractor);
         context.wrapAndPut(BatchMappingAnnoHandler.class, batchMappingExtractor);
+        context.wrapAndPut(SubscriptionMappingAnnoHandler.class, subscriptionMappingAnnoHandler);
 
         context.lifecycle(-99, () -> {
             context.beanMake(GraphqlProperties.class);
@@ -65,6 +73,7 @@ public class GraphqlPlugin implements Plugin {
             context.beanMake(GraphqlConfiguration.class);
             context.beanMake(GraphiqlController.class);
             context.beanMake(GraphqlController.class);
+            context.beanMake(GraphqlWebsocket.class);
         });
 
         EventBus.subscribe(AppLoadEndEvent.class, new AppLoadEndEventListener());

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/BaseSchemaMappingAnnoHandler.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/BaseSchemaMappingAnnoHandler.java
@@ -50,18 +50,22 @@ public abstract class BaseSchemaMappingAnnoHandler<T extends Annotation> impleme
     }
 
     protected DataFetcher<Object> getDataFetcher(AppContext context, BeanWrap wrap,
-            Method method) {
-        boolean isBatch = this.getIsBatch();
+        Method method) {
+        boolean isBatch = this.isBatch();
         return new SchemaMappingDataFetcher(context, wrap, method, isBatch);
     }
 
-    protected boolean getIsBatch() {
+    protected boolean isBatch() {
+        return false;
+    }
+
+    protected boolean isSubscription() {
         return false;
     }
 
     abstract String getTypeName(BeanWrap wrap, Method method,
-            T schemaMapping);
+        T schemaMapping);
 
     abstract String getFieldName(BeanWrap wrap, Method method,
-            T schemaMapping);
+        T schemaMapping);
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/BatchMappingAnnoHandler.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/BatchMappingAnnoHandler.java
@@ -99,7 +99,7 @@ public class BatchMappingAnnoHandler extends BaseSchemaMappingAnnoHandler<BatchM
     }
 
     @Override
-    protected boolean getIsBatch() {
+    protected boolean isBatch() {
         return true;
     }
 

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMapping.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMapping.java
@@ -1,0 +1,26 @@
+package graphql.solon.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.noear.solon.annotation.Alias;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SubscriptionMapping {
+
+    @Alias("value")
+    String name() default "";
+
+    @Alias("name")
+    String value() default "";
+
+    String typeName() default "Subscription";
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMappingAnnoHandler.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMappingAnnoHandler.java
@@ -1,0 +1,61 @@
+package graphql.solon.annotation;
+
+import graphql.schema.DataFetcher;
+import graphql.solon.fetcher.DataFetcherWrap;
+import java.lang.reflect.Method;
+import org.apache.commons.lang3.StringUtils;
+import org.noear.solon.Utils;
+import org.noear.solon.core.AppContext;
+import org.noear.solon.core.BeanWrap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+public class SubscriptionMappingAnnoHandler extends
+    BaseSchemaMappingAnnoHandler<SubscriptionMapping> {
+
+    private static Logger log = LoggerFactory.getLogger(SubscriptionMappingAnnoHandler.class);
+
+    public SubscriptionMappingAnnoHandler(AppContext context) {
+        super(context);
+    }
+
+    @Override
+    public void doExtract(BeanWrap wrap, Method method, SubscriptionMapping schemaMapping)
+        throws Throwable {
+        String typeName = this.getTypeName(wrap, method, schemaMapping);
+        String fieldName = this.getFieldName(wrap, method, schemaMapping);
+
+        DataFetcher<Object> dataFetcher = this.getDataFetcher(context, wrap, method);
+        DataFetcherWrap fetcherWrap = new DataFetcherWrap(typeName, fieldName, dataFetcher);
+        log.debug("扫描到 typeName: [{}],fieldName: [{}] 的 SchemaMappingDataFetcher", typeName,
+            fieldName);
+        this.wrapList.add(fetcherWrap);
+    }
+
+    @Override
+    String getTypeName(BeanWrap wrap, Method method,
+        SubscriptionMapping schemaMapping) {
+        return schemaMapping.typeName();
+    }
+
+    @Override
+    String getFieldName(BeanWrap wrap, Method method,
+        SubscriptionMapping schemaMapping) {
+        String fieldName = Utils.annoAlias(schemaMapping.name(), schemaMapping.value());
+
+        if (StringUtils.isBlank(fieldName)) {
+            // 注解没标就使用方法名
+            fieldName = method.getName();
+        }
+        return fieldName;
+    }
+
+    @Override
+    protected boolean isSubscription() {
+        return true;
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/config/GraphqlConfiguration.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/config/GraphqlConfiguration.java
@@ -2,6 +2,7 @@ package graphql.solon.config;
 
 import graphql.solon.execution.DefaultGraphQlSource;
 import graphql.solon.execution.GraphQlSource;
+import graphql.solon.support.WebGraphQlHandlerGetter;
 import org.noear.solon.annotation.Bean;
 import org.noear.solon.annotation.Configuration;
 import org.slf4j.Logger;
@@ -15,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class GraphqlConfiguration {
 
     private static Logger log = LoggerFactory.getLogger(GraphqlConfiguration.class);
-
+    
     public GraphqlConfiguration() {
     }
 
@@ -27,6 +28,11 @@ public class GraphqlConfiguration {
         DefaultGraphQlSource defaultGraphQlSource = new DefaultGraphQlSource();
         log.debug("注册默认的 GraphQlSource");
         return defaultGraphQlSource;
+    }
+
+    @Bean
+    public WebGraphQlHandlerGetter defaultWebGraphQlHandlerGetter() {
+        return new WebGraphQlHandlerGetter();
     }
 
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/configurer/ThreadLocalAccessorCollect.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/configurer/ThreadLocalAccessorCollect.java
@@ -1,0 +1,12 @@
+package graphql.solon.configurer;
+
+import graphql.solon.collect.AbstractBaseCollector;
+import graphql.solon.execution.ThreadLocalAccessor;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+public class ThreadLocalAccessorCollect extends AbstractBaseCollector<ThreadLocalAccessor> {
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/configurer/WebGraphQlInterceptorCollect.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/configurer/WebGraphQlInterceptorCollect.java
@@ -1,0 +1,12 @@
+package graphql.solon.configurer;
+
+import graphql.solon.collect.AbstractBaseCollector;
+import graphql.solon.support.WebGraphQlInterceptor;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+public class WebGraphQlInterceptorCollect extends AbstractBaseCollector<WebGraphQlInterceptor> {
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/controller/GraphqlController.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/controller/GraphqlController.java
@@ -48,7 +48,7 @@ public class GraphqlController {
 
     @Post
     @Mapping("/schema")
-    public String getSchema(Object data, Context request) {
+    public String getSchema() {
         return new SchemaPrinter().print(this.graphQlSource.schema());
     }
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/execution/DefaultExecutionGraphQlService.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/execution/DefaultExecutionGraphQlService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.execution;
+
+import graphql.ExecutionInput;
+import graphql.GraphQL;
+import graphql.GraphQLContext;
+import graphql.execution.ExecutionIdProvider;
+import graphql.solon.support.DefaultExecutionGraphQlResponse;
+import graphql.solon.support.ExecutionGraphQlRequest;
+import graphql.solon.support.ExecutionGraphQlResponse;
+import graphql.solon.support.ExecutionGraphQlService;
+import java.util.function.BiFunction;
+import org.noear.solon.core.handle.Context;
+import org.noear.solon.core.handle.ContextEmpty;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link ExecutionGraphQlService} that uses a {@link GraphQlSource} to obtain a
+ * {@link GraphQL} instance and perform query execution.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public class DefaultExecutionGraphQlService implements ExecutionGraphQlService {
+
+    private static final BiFunction<ExecutionInput, ExecutionInput.Builder, ExecutionInput> RESET_EXECUTION_ID_CONFIGURER =
+        (executionInput, builder) -> builder.executionId(null).build();
+
+
+    private final GraphQlSource graphQlSource;
+
+    private final boolean isDefaultExecutionIdProvider;
+
+
+    public DefaultExecutionGraphQlService(GraphQlSource graphQlSource) {
+        this.graphQlSource = graphQlSource;
+        this.isDefaultExecutionIdProvider =
+            (graphQlSource.graphQl().getIdProvider()
+                == ExecutionIdProvider.DEFAULT_EXECUTION_ID_PROVIDER);
+    }
+
+    @Override
+    public final Mono<ExecutionGraphQlResponse> execute(ExecutionGraphQlRequest request) {
+        return Mono.deferContextual((contextView) -> {
+            if (!this.isDefaultExecutionIdProvider && request.getExecutionId() == null) {
+                request.configureExecutionInput(RESET_EXECUTION_ID_CONFIGURER);
+            }
+            ExecutionInput executionInput = request.toExecutionInput();
+            GraphQLContext graphQLContext = executionInput.getGraphQLContext();
+            graphQLContext.put(Context.class, ContextEmpty.create());
+            ReactorContextManager
+                .setReactorContext(contextView, executionInput.getGraphQLContext());
+            ExecutionInput updatedExecutionInput = registerDataLoaders(executionInput);
+            return Mono.fromFuture(this.graphQlSource.graphQl().executeAsync(updatedExecutionInput))
+                .map(result -> new DefaultExecutionGraphQlResponse(updatedExecutionInput, result));
+        });
+    }
+
+    private ExecutionInput registerDataLoaders(ExecutionInput executionInput) {
+        ExecutionInput newExecutionInput = this.graphQlSource.registerDataLoaders(executionInput);
+        return newExecutionInput;
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/AbstractGraphQlResponse.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/AbstractGraphQlResponse.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+
+import graphql.solon.util.Assert;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.noear.snack.core.utils.StringUtil;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * Base class for {@link GraphQlResponse} that pre-implements the ability to
+ * access a {@link ResponseField}.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public abstract class AbstractGraphQlResponse implements GraphQlResponse {
+
+
+    @Override
+    public ResponseField field(String path) {
+        return new DefaultResponseField(this, path);
+    }
+
+
+    /**
+     * Default implementation of {@link ResponseField}.
+     */
+    private static class DefaultResponseField implements ResponseField {
+
+        private final GraphQlResponse response;
+
+        private final String path;
+
+        private final List<Object> parsedPath;
+
+        @Nullable
+        private final Object value;
+
+        private final List<ResponseError> fieldErrors;
+
+
+        DefaultResponseField(GraphQlResponse response, String path) {
+            this.response = response;
+            this.path = path;
+            this.parsedPath = parsePath(path);
+            this.value = initFieldValue(this.parsedPath, response);
+            this.fieldErrors = initFieldErrors(path, response);
+        }
+
+        private static List<Object> parsePath(String path) {
+            if (StringUtil.isEmpty(path)) {
+                return Collections.emptyList();
+            }
+
+            String invalidPathMessage = "Invalid path: '" + path + "'";
+            List<Object> dataPath = new ArrayList<>();
+
+            StringBuilder sb = new StringBuilder();
+            boolean readingIndex = false;
+
+            for (int i = 0; i < path.length(); i++) {
+                char c = path.charAt(i);
+                switch (c) {
+                    case '.':
+                    case '[':
+                        Assert.isTrue(!readingIndex, invalidPathMessage);
+                        break;
+                    case ']':
+                        i++;
+                        Assert.isTrue(readingIndex, invalidPathMessage);
+                        Assert.isTrue(i == path.length() || path.charAt(i) == '.',
+                            invalidPathMessage);
+                        break;
+                    default:
+                        sb.append(c);
+                        if (i < path.length() - 1) {
+                            continue;
+                        }
+                }
+                String token = sb.toString();
+                Assert.hasText(token, invalidPathMessage);
+                dataPath.add(readingIndex ? Integer.parseInt(token) : token);
+                sb.delete(0, sb.length());
+
+                readingIndex = (c == '[');
+            }
+
+            return dataPath;
+        }
+
+        @Nullable
+        private static Object initFieldValue(List<Object> path, GraphQlResponse response) {
+            Object value = (response.isValid() ? response.getData() : null);
+            for (Object segment : path) {
+                if (value == null) {
+                    return null;
+                }
+                if (segment instanceof String) {
+                    Assert.isTrue(value instanceof Map,
+                        () -> "Invalid path " + path + ", data: " + response.getData());
+                    value = ((Map<?, ?>) value).getOrDefault(segment, null);
+                } else {
+                    Assert.isTrue(value instanceof List,
+                        () -> "Invalid path " + path + ", data: " + response.getData());
+                    int index = (int) segment;
+                    value = (index < ((List<?>) value).size() ? ((List<?>) value).get(index)
+                        : null);
+                }
+            }
+            return value;
+        }
+
+        /**
+         * Return field errors whose path starts with the given field path.
+         *
+         * @param path the field path to match
+         * @return errors whose path starts with the dataPath
+         */
+        private static List<ResponseError> initFieldErrors(String path, GraphQlResponse response) {
+            if (path.isEmpty() || response.getErrors().isEmpty()) {
+                return Collections.emptyList();
+            }
+            return response.getErrors().stream()
+                .filter(error -> {
+                    String errorPath = error.getPath();
+                    return !errorPath.isEmpty() && (errorPath.startsWith(path) || path
+                        .startsWith(errorPath));
+                })
+                .collect(Collectors.toList());
+        }
+
+
+        @Override
+        public String getPath() {
+            return this.path;
+        }
+
+        @Override
+        public List<Object> getParsedPath() {
+            return this.parsedPath;
+        }
+
+        @Override
+        public boolean hasValue() {
+            return (this.value != null);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T getValue() {
+            return (T) this.value;
+        }
+
+        @Override
+        public ResponseError getError() {
+            if (!hasValue()) {
+                if (!this.fieldErrors.isEmpty()) {
+                    return this.fieldErrors.get(0);
+                }
+                if (!this.response.getErrors().isEmpty()) {
+                    return this.response.getErrors().get(0);
+                }
+                // No errors, set to null by DataFetcher
+            }
+            return null;
+        }
+
+        @Override
+        public List<ResponseError> getErrors() {
+            return this.fieldErrors;
+        }
+
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultExecutionGraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultExecutionGraphQlRequest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.ExecutionInput;
+import graphql.execution.ExecutionId;
+import graphql.solon.util.Assert;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * {@link GraphQlRequest} for server side handling, adding the transport (e.g. HTTP
+ * or WebSocket handler) assigned {@link #getId() id} and {@link #getLocale()
+ * locale} in the addition to the {@code GraphQlRequest} inputs.
+ *
+ * <p>Supports the initialization of {@link ExecutionInput} that is passed to
+ * {@link graphql.GraphQL}. You can customize that via
+ * {@link #configureExecutionInput(BiFunction)}.
+ *
+ * @author Rossen Stoyanchev
+ * @author Brian Clozel
+ * @since 1.0.0
+ */
+public class DefaultExecutionGraphQlRequest extends DefaultGraphQlRequest implements
+    ExecutionGraphQlRequest {
+
+    private final String id;
+
+    @Nullable
+    private ExecutionId executionId;
+
+    @Nullable
+    private final Locale locale;
+
+    private final List<BiFunction<ExecutionInput, ExecutionInput.Builder, ExecutionInput>> executionInputConfigurers = new ArrayList<>();
+
+
+    /**
+     * Create an instance.
+     *
+     * @param document textual representation of the operation(s)
+     * @param operationName optionally, the name of the operation to execute
+     * @param variables variables by which the query is parameterized
+     * @param extensions implementor specific, protocol extensions
+     * @param id the request id, to be used as the {@link ExecutionId}
+     * @param locale the locale associated with the request
+     */
+    public DefaultExecutionGraphQlRequest(
+        String document, @Nullable String operationName,
+        @Nullable Map<String, Object> variables, @Nullable Map<String, Object> extensions,
+        String id, @Nullable Locale locale) {
+
+        super(document, operationName, variables, extensions);
+        Assert.notNull(id, "'id' is required");
+        this.id = id;
+        this.locale = locale;
+    }
+
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public void executionId(ExecutionId executionId) {
+        Assert.notNull(executionId, "executionId is required");
+        this.executionId = executionId;
+    }
+
+    @Override
+    @Nullable
+    public ExecutionId getExecutionId() {
+        return this.executionId;
+    }
+
+    @Override
+    @Nullable
+    public Locale getLocale() {
+        return this.locale;
+    }
+
+    @Override
+    public void configureExecutionInput(
+        BiFunction<ExecutionInput, ExecutionInput.Builder, ExecutionInput> configurer) {
+        this.executionInputConfigurers.add(configurer);
+    }
+
+    @Override
+    public ExecutionInput toExecutionInput() {
+        ExecutionInput.Builder inputBuilder = ExecutionInput.newExecutionInput()
+            .query(getDocument())
+            .operationName(getOperationName())
+            .variables(getVariables())
+            .extensions(getExtensions())
+            .locale(this.locale)
+            .executionId(this.executionId != null ? this.executionId : ExecutionId.from(this.id));
+
+        ExecutionInput executionInput = inputBuilder.build();
+
+        for (BiFunction<ExecutionInput, ExecutionInput.Builder, ExecutionInput> configurer : this.executionInputConfigurers) {
+            ExecutionInput current = executionInput;
+            executionInput = executionInput
+                .transform(builder -> configurer.apply(current, builder));
+        }
+
+        return executionInput;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ", id=" + getId() + (getLocale() != null ? ", Locale="
+            + getLocale() : "");
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultExecutionGraphQlResponse.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultExecutionGraphQlResponse.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package graphql.solon.support;
+
+import graphql.ErrorClassification;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import graphql.solon.util.Assert;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * {@link GraphQlResponse} for server use that wraps the {@link ExecutionResult}
+ * returned from {@link graphql.GraphQL} and also exposes the actual
+ * {@link ExecutionInput} instance passed into it.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public class DefaultExecutionGraphQlResponse extends AbstractGraphQlResponse implements
+    ExecutionGraphQlResponse {
+
+    private final ExecutionInput input;
+
+    private final ExecutionResult result;
+
+
+    /**
+     * Constructor to create initial instance.
+     */
+    public DefaultExecutionGraphQlResponse(ExecutionInput input, ExecutionResult result) {
+        Assert.notNull(input, "ExecutionInput is required");
+        Assert.notNull(result, "ExecutionResult is required");
+        this.input = input;
+        this.result = result;
+    }
+
+    /**
+     * Constructor to re-wrap from transport specific subclass.
+     */
+    protected DefaultExecutionGraphQlResponse(ExecutionGraphQlResponse response) {
+        this(response.getExecutionInput(), response.getExecutionResult());
+    }
+
+
+    @Override
+    public ExecutionInput getExecutionInput() {
+        return this.input;
+    }
+
+    @Override
+    public ExecutionResult getExecutionResult() {
+        return this.result;
+    }
+
+    @Override
+    public boolean isValid() {
+        return (this.result.isDataPresent() && this.result.getData() != null);
+    }
+
+    @Nullable
+    @Override
+    public <T> T getData() {
+        return this.result.getData();
+    }
+
+    @Override
+    public List<ResponseError> getErrors() {
+        return this.result.getErrors().stream().map(Error::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<Object, Object> getExtensions() {
+        return (this.result.getExtensions() != null ? this.result.getExtensions()
+            : Collections.emptyMap());
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        return this.result.toSpecification();
+    }
+
+    @Override
+    public String toString() {
+        return this.result.toString();
+    }
+
+
+    /**
+     * {@link GraphQLError} that wraps a {@link GraphQLError}.
+     */
+    private static class Error implements ResponseError {
+
+        private final GraphQLError delegate;
+
+        Error(GraphQLError delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getMessage() {
+            return this.delegate.getMessage();
+        }
+
+        @Override
+        public List<SourceLocation> getLocations() {
+            return this.delegate.getLocations();
+        }
+
+        @Override
+        public ErrorClassification getErrorType() {
+            return this.delegate.getErrorType();
+        }
+
+        @Override
+        public String getPath() {
+            return getParsedPath().stream()
+                .reduce("",
+                    (s, o) -> s + (o instanceof Integer ? "[" + o + "]"
+                        : (s.isEmpty() ? o : "." + o)),
+                    (s, s2) -> null);
+        }
+
+        @Override
+        public List<Object> getParsedPath() {
+            return (this.delegate.getPath() != null ? this.delegate.getPath()
+                : Collections.emptyList());
+        }
+
+        @Override
+        public Map<String, Object> getExtensions() {
+            return (this.delegate.getExtensions() != null ? this.delegate.getExtensions()
+                : Collections.emptyMap());
+        }
+
+        @Override
+        public String toString() {
+            return this.delegate.toString();
+        }
+
+    }
+
+
+    /**
+     * Builder to transform the response's {@link ExecutionResult}.
+     */
+    public static abstract class Builder<B extends Builder<B, R>, R extends ExecutionGraphQlResponse> {
+
+        private final R original;
+
+        private final ExecutionResultImpl.Builder executionResultBuilder;
+
+        protected Builder(R original) {
+            this.original = original;
+            this.executionResultBuilder = ExecutionResultImpl.newExecutionResult()
+                .from(original.getExecutionResult());
+        }
+
+        /**
+         * Set the {@link ExecutionResult#getData() data} of the GraphQL execution result.
+         *
+         * @param data the execution result data
+         * @return the current builder
+         */
+        public Builder<B, R> data(Object data) {
+            this.executionResultBuilder.data(data);
+            return this;
+        }
+
+        /**
+         * Set the {@link ExecutionResult#getErrors() errors} of the GraphQL execution
+         * result.
+         *
+         * @param errors the execution result errors
+         * @return the current builder
+         */
+        public Builder<B, R> errors(@Nullable List<GraphQLError> errors) {
+            this.executionResultBuilder.errors(errors);
+            return this;
+        }
+
+        /**
+         * Set the {@link ExecutionResult#getExtensions() extensions} of the GraphQL
+         * execution result.
+         *
+         * @param extensions the execution result extensions
+         * @return the current builder
+         */
+        public Builder<B, R> extensions(@Nullable Map<Object, Object> extensions) {
+            this.executionResultBuilder.extensions(extensions);
+            return this;
+        }
+
+        /**
+         * Build the response with the transformed {@code ExecutionResult}.
+         */
+        public R build() {
+            return build(this.original, this.executionResultBuilder.build());
+        }
+
+        /**
+         * Subclasses to create the specific response instance.
+         */
+        protected abstract R build(R original, ExecutionResult newResult);
+
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultGraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultGraphQlRequest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.solon.util.Assert;
+import graphql.solon.util.ObjectUtils;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * Default implementation of {@link GraphQlRequest}.
+ *
+ * @author Rossen Stoyanchev
+ * @author Brian Clozel
+ * @since 1.0.0
+ */
+public class DefaultGraphQlRequest implements GraphQlRequest {
+
+    private final String document;
+
+    @Nullable
+    private final String operationName;
+
+    private final Map<String, Object> variables;
+
+    private final Map<String, Object> extensions;
+
+
+    /**
+     * Create a request.
+     *
+     * @param document textual representation of the operation(s)
+     */
+    public DefaultGraphQlRequest(String document) {
+        this(document, null, null, null);
+    }
+
+    /**
+     * Create a request with a complete set of inputs.
+     *
+     * @param document textual representation of the operation(s)
+     * @param operationName optionally, the name of the operation to execute
+     * @param variables variables by which the operation is parameterized
+     * @param extensions implementor specific, protocol extensions
+     */
+    public DefaultGraphQlRequest(
+        String document, @Nullable String operationName,
+        @Nullable Map<String, Object> variables, @Nullable Map<String, Object> extensions) {
+
+        Assert.notNull(document, "'document' is required");
+        this.document = document;
+        this.operationName = operationName;
+        this.variables = (variables != null ? variables : Collections.emptyMap());
+        this.extensions = (extensions != null ? extensions : Collections.emptyMap());
+    }
+
+
+    @Override
+    public String getDocument() {
+        return this.document;
+    }
+
+    @Override
+    @Nullable
+    public String getOperationName() {
+        return this.operationName;
+    }
+
+    @Override
+    public Map<String, Object> getVariables() {
+        return this.variables;
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return this.extensions;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>(3);
+        map.put("query", getDocument());
+        if (getOperationName() != null) {
+            map.put("operationName", getOperationName());
+        }
+        if (!MapUtils.isEmpty(getVariables())) {
+            map.put("variables", new LinkedHashMap<>(getVariables()));
+        }
+        if (!MapUtils.isEmpty(getExtensions())) {
+            map.put("extensions", new LinkedHashMap<>(getExtensions()));
+        }
+        return map;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DefaultGraphQlRequest)) {
+            return false;
+        }
+        DefaultGraphQlRequest other = (DefaultGraphQlRequest) o;
+        return (getDocument().equals(other.getDocument()) &&
+            ObjectUtils.nullSafeEquals(getOperationName(), other.getOperationName()) &&
+            ObjectUtils.nullSafeEquals(getVariables(), other.getVariables()) &&
+            ObjectUtils.nullSafeEquals(getExtensions(), other.getExtensions()));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.document.hashCode() +
+            31 * ObjectUtils.nullSafeHashCode(this.operationName) +
+            31 * this.variables.hashCode() +
+            31 * this.extensions.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "document='" + getDocument() + "'" +
+            ((getOperationName() != null) ? ", operationName='" + getOperationName() + "'" : "") +
+            (!MapUtils.isEmpty(getVariables()) ? ", variables=" + getVariables() : "" +
+                (!MapUtils.isEmpty(getExtensions()) ? ", extensions=" + getExtensions()
+                    : ""));
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultWebGraphQlHandlerBuilder.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/DefaultWebGraphQlHandlerBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.solon.execution.ReactorContextManager;
+import graphql.solon.execution.ThreadLocalAccessor;
+import graphql.solon.support.WebGraphQlInterceptor.Chain;
+import graphql.solon.util.Assert;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.noear.solon.lang.Nullable;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * Default implementation of {@link WebGraphQlHandler.Builder}.
+ *
+ * @author Rossen Stoyanchev
+ */
+class DefaultWebGraphQlHandlerBuilder implements WebGraphQlHandler.Builder {
+
+    private final ExecutionGraphQlService service;
+
+    private final List<WebGraphQlInterceptor> interceptors = new ArrayList<>();
+
+    @Nullable
+    private WebSocketGraphQlInterceptor webSocketInterceptor;
+
+    @Nullable
+    private List<ThreadLocalAccessor> accessors;
+
+
+    DefaultWebGraphQlHandlerBuilder(ExecutionGraphQlService service) {
+        Assert.notNull(service, "GraphQlService is required");
+        this.service = service;
+    }
+
+
+    @Override
+    public WebGraphQlHandler.Builder interceptor(WebGraphQlInterceptor... interceptors) {
+        return interceptors(Arrays.asList(interceptors));
+    }
+
+    @Override
+    public WebGraphQlHandler.Builder interceptors(List<WebGraphQlInterceptor> interceptors) {
+        this.interceptors.addAll(interceptors);
+        interceptors.forEach(interceptor -> {
+            if (interceptor instanceof WebSocketGraphQlInterceptor) {
+                Assert.isNull(this.webSocketInterceptor,
+                    "There can be at most 1 WebSocketInterceptor");
+                this.webSocketInterceptor = (WebSocketGraphQlInterceptor) interceptor;
+            }
+        });
+        return this;
+    }
+
+    @Override
+    public WebGraphQlHandler.Builder threadLocalAccessor(ThreadLocalAccessor... accessors) {
+        return threadLocalAccessors(Arrays.asList(accessors));
+    }
+
+    @Override
+    public WebGraphQlHandler.Builder threadLocalAccessors(List<ThreadLocalAccessor> accessors) {
+        if (CollectionUtils.isNotEmpty(accessors)) {
+            this.accessors = (this.accessors != null) ? this.accessors : new ArrayList<>();
+            this.accessors.addAll(accessors);
+        }
+        return this;
+    }
+
+    @Override
+    public WebGraphQlHandler build() {
+
+        Chain endOfChain = request -> this.service.execute(request).map(WebGraphQlResponse::new);
+
+        Chain executionChain = this.interceptors.stream()
+            .reduce(WebGraphQlInterceptor::andThen)
+            .map(interceptor -> interceptor.apply(endOfChain))
+            .orElse(endOfChain);
+
+        ThreadLocalAccessor accessor = (CollectionUtils.isEmpty(this.accessors) ? null :
+            ThreadLocalAccessor.composite(this.accessors));
+
+        return new WebGraphQlHandler() {
+
+            @Override
+            public WebSocketGraphQlInterceptor getWebSocketInterceptor() {
+                return (webSocketInterceptor != null ?
+                    webSocketInterceptor : new WebSocketGraphQlInterceptor() {
+                });
+            }
+
+            @Nullable
+            @Override
+            public ThreadLocalAccessor getThreadLocalAccessor() {
+                return accessor;
+            }
+
+            @Override
+            public Mono<WebGraphQlResponse> handleRequest(WebGraphQlRequest request) {
+                return executionChain.next(request)
+                    .contextWrite(context -> {
+                        if (accessor != null) {
+                            return ReactorContextManager
+                                .extractThreadLocalValues(accessor, context);
+                        }
+                        return context;
+                    });
+            }
+
+        };
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlRequest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.ExecutionInput;
+import graphql.execution.ExecutionId;
+import java.util.Locale;
+import java.util.function.BiFunction;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * Implementation of {@link GraphQlRequest} for request handling through GraphQL
+ * Java with support for customizing the {@link ExecutionInput} passed into
+ * {@link graphql.GraphQL}.
+ *
+ * @author Rossen Stoyanchev
+ * @author Brian Clozel
+ * @since 1.0.0
+ */
+public interface ExecutionGraphQlRequest extends GraphQlRequest {
+
+    /**
+     * Return the transport assigned id for the request that in turn sets
+     * {@link ExecutionInput.Builder#executionId(ExecutionId) executionId}.
+     * <p>By default, the id is initialized as follows:
+     * <ul>
+     * <li>On WebFlux, this is the {@code ServerHttpRequest} id which correlates
+     * to WebFlux log messages. For Reactor Netty, it also correlates to server
+     * log messages.
+     * <li>On Spring MVC, the id is generated via
+     * {@link org.springframework.util.AlternativeJdkIdGenerator}, which does
+     * not correlate to anything, but is more efficient than the default
+     * {@link graphql.execution.ExecutionIdProvider} which relies on
+     * {@code UUID.randomUUID()}.
+     * <li>On WebSocket, the id is set to the message id of the {@code "subscribe"}
+     * message from the GraphQL over WebSocket protocol that is used to correlate
+     * request and response messages on the the WebSocket.
+     * </ul>
+     * <p>To override this id, use {@link #executionId(ExecutionId)} or configure
+     * {@link graphql.GraphQL} with an {@link graphql.execution.ExecutionIdProvider}.
+     *
+     * @return the request id
+     */
+    String getId();
+
+    /**
+     * Configure the {@link ExecutionId} to set on
+     * {@link ExecutionInput#getExecutionId()}, overriding the transport assigned
+     * {@link #getId() id}.
+     *
+     * @param executionId the id to use
+     */
+    void executionId(ExecutionId executionId);
+
+    /**
+     * Return the configured {@link #executionId(ExecutionId) executionId}.
+     */
+    @Nullable
+    ExecutionId getExecutionId();
+
+    /**
+     * Return the transport assigned locale value, if any.
+     */
+    @Nullable
+    Locale getLocale();
+
+    /**
+     * Provide a {@code BiFunction} to help initialize the {@link ExecutionInput}
+     * passed to {@link graphql.GraphQL}. The {@code ExecutionInput} is first
+     * pre-populated with values from "this" {@code ExecutionGraphQlRequest}, and
+     * is then customized with the functions provided here.
+     *
+     * @param configurer a {@code BiFunction} that accepts the
+     * {@code ExecutionInput} initialized so far, and a builder to customize it.
+     */
+    void configureExecutionInput(
+        BiFunction<ExecutionInput, ExecutionInput.Builder, ExecutionInput> configurer);
+
+    /**
+     * Create the {@link ExecutionInput} to pass to {@link graphql.GraphQL}.
+     * passed to {@link graphql.GraphQL}. The {@code ExecutionInput} is populated
+     * with values from "this" {@code ExecutionGraphQlRequest}, and then customized
+     * with functions provided via {@link #configureExecutionInput(BiFunction)}.
+     *
+     * @return the resulting {@code ExecutionInput}
+     */
+    ExecutionInput toExecutionInput();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlResponse.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+
+
+/**
+ * Implementation of {@link GraphQlResponse} that wraps the {@link ExecutionResult}
+ * returned from {@link graphql.GraphQL} to expose it as {@link GraphQlResponse},
+ * also providing access to the {@link ExecutionInput} used for the request.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface ExecutionGraphQlResponse extends GraphQlResponse {
+
+    /**
+     * Return the {@link ExecutionInput} that was prepared through the
+     * {@link ExecutionGraphQlRequest} and passed to {@link graphql.GraphQL}.
+     */
+    ExecutionInput getExecutionInput();
+
+    /**
+     * Return the {@link ExecutionResult} that was returned from the invocation
+     * to {@link graphql.GraphQL}.
+     */
+    ExecutionResult getExecutionResult();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlService.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ExecutionGraphQlService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Strategy to execute a GraphQL request by invoking GraphQL Java.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface ExecutionGraphQlService {
+
+    /**
+     * Execute the request and return the response.
+     *
+     * @param request the request to execute
+     * @return the resulting response
+     */
+    Mono<ExecutionGraphQlResponse> execute(
+        ExecutionGraphQlRequest request);
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/GraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/GraphQlRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * Represents a GraphQL request with the inputs to pass to a GraphQL service
+ * including a {@link #getDocument() document}, {@link #getOperationName()
+ * operationName}, and {@link #getVariables() variables}.
+ *
+ * <p>The request can be turned to a Map via {@link #toMap()} and to be
+ * submitted as JSON over HTTP or WebSocket.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface GraphQlRequest {
+
+    /**
+     * Return the GraphQL document which is the textual representation of an
+     * operation (or operations) to perform, including any selection sets and
+     * fragments.
+     */
+    String getDocument();
+
+    /**
+     * Return the name of the operation in the {@link #getDocument() document}
+     * to execute, if the document contains multiple operations.
+     */
+    @Nullable
+    String getOperationName();
+
+    /**
+     * Return values for variable defined by the operation.
+     */
+    Map<String, Object> getVariables();
+
+    /**
+     * Return implementor specific, protocol extensions, if any.
+     */
+    Map<String, Object> getExtensions();
+
+    /**
+     * Convert the request to a {@link Map} as defined in
+     * <a href="https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md">GraphQL over HTTP</a> and
+     * <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md">GraphQL over WebSocket</a>:
+     * <table>
+     * <tr><th>Key</th><th>Value</th></tr>
+     * <tr><td>query</td><td>{@link #getDocument() document}</td></tr>
+     * <tr><td>operationName</td><td>{@link #getOperationName() operationName}</td></tr>
+     * <tr><td>variables</td><td>{@link #getVariables() variables}</td></tr>
+     * </table>
+     */
+    Map<String, Object> toMap();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/GraphQlResponse.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/GraphQlResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+
+import java.util.List;
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * Represents a GraphQL response with the result of executing a request operation.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface GraphQlResponse {
+
+    /**
+     * Whether the response is valid. A response is invalid in one of the
+     * following two cases:
+     * <ul>
+     * <li>the {@link #toMap() response map} has no "data" entry indicating
+     * errors before execution, e.g. grammar parse and validation
+     * <li>the "data" entry has a {@code null} value indicating errors during
+     * execution that prevented a valid response
+     * </ul>
+     * <p>A valid response has a "data" key with a {@code non-null} value, but
+     * it may still be partial and have some fields set to {@code null} due to
+     * field errors.
+     * <p>For more details, see section 7 "Response" in the GraphQL spec.
+     */
+    boolean isValid();
+
+    /**
+     * Return the data part of the response, or {@code null} when the response
+     * is not {@link #isValid() valid}.
+     *
+     * @param <T> a map or a list
+     */
+    @Nullable
+    <T> T getData();
+
+    /**
+     * Return errors included in the response.
+     * <p>A response that is not {@link #isValid() valid} contains "request
+     * errors". Those are errors that apply to the request as a whole, and have
+     * an empty error {@link ResponseError#getPath() path}.
+     * <p>A response that is valid may still be partial and contain "field
+     * errors". Those are errors associated with a specific field through their
+     * error path.
+     */
+    List<ResponseError> getErrors();
+
+    /**
+     * Navigate to the given path under the "data" key of the response map where
+     * the path is a dot-separated string with optional array indexes.
+     * <p>Example paths:
+     * <pre>
+     * "hero"
+     * "hero.name"
+     * "hero.friends"
+     * "hero.friends[2]"
+     * "hero.friends[2].name"
+     * </pre>
+     *
+     * @param path relative to the "data" key
+     * @return representation for the field with further options to inspect or
+     * decode its value; use {@link ResponseField#hasValue()} to check if
+     * the field actually exists and has a value.
+     */
+    ResponseField field(String path);
+
+    /**
+     * Return implementor specific, protocol extensions, if any.
+     */
+    Map<Object, Object> getExtensions();
+
+    /**
+     * Return a map representation of the response, formatted as required in the
+     * "Response" section of the GraphQL spec.
+     */
+    Map<String, Object> toMap();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ResponseError.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ResponseError.java
@@ -1,0 +1,76 @@
+package graphql.solon.support;
+
+import graphql.ErrorClassification;
+import graphql.language.SourceLocation;
+import java.util.List;
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * Represents a GraphQL response error.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0
+ */
+public interface ResponseError {
+
+    /**
+     * Return the message with a description of the error intended for the
+     * developer as a guide to understand and correct the error.
+     */
+    @Nullable
+    String getMessage();
+
+    /**
+     * Return a classification for the error that is specific to GraphQL Java.
+     * This is serialized under {@link #getExtensions() "extensions"} in the
+     * response map.
+     *
+     * @see graphql.ErrorType
+     * @see org.springframework.graphql.execution.ErrorType
+     */
+    ErrorClassification getErrorType();
+
+    /**
+     * Return a String representation of the {@link #getParsedPath() parsed path},
+     * or an empty String if the error is not associated with a field.
+     * <p>Example paths:
+     * <pre>
+     * "hero"
+     * "hero.name"
+     * "hero.friends"
+     * "hero.friends[2]"
+     * "hero.friends[2].name"
+     * </pre>
+     */
+    String getPath();
+
+    /**
+     * Return the path to a response field which experienced the error,
+     * if the error can be associated to a particular field in the result, or
+     * otherwise an empty list. This allows a client to identify whether a
+     * {@code null} result is intentional or caused by an error.
+     * <p>This list contains path segments starting at the root of the response
+     * and ending with the field associated with the error. Path segments that
+     * represent fields are strings, and path segments that represent list
+     * indices are 0-indexed integers. If the error happens in an aliased field,
+     * the path uses the aliased name, since it represents a path in the
+     * response, not in the request.
+     */
+    List<Object> getParsedPath();
+
+    /**
+     * Return a list of locations in the GraphQL document, if the error can be
+     * associated to a particular point in the document. Each location has a
+     * line and a column, both positive, starting from 1 and describing the
+     * beginning of an associated syntax element.
+     */
+    List<SourceLocation> getLocations();
+
+    /**
+     * Return a map with GraphQL Java and other implementation specific protocol
+     * error detail extensions such as {@link #getErrorType()}, possibly empty.
+     */
+    Map<String, Object> getExtensions();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ResponseField.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/ResponseField.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import java.util.List;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * Representation for a field in a GraphQL response, with options to examine
+ * the field value and errors.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface ResponseField {
+
+    /**
+     * Whether the field has a value.
+     * <ul>
+     * <li>{@code "true"} means the field is not {@code null}, and therefore valid,
+     * although it may be partial with nested field {@link #getErrors() errors}.
+     * <li>{@code "false"} means the field is {@code null} or doesn't exist; use
+     * {@link #getError()} to check if the field is {@code null} due to an error.
+     * </ul>
+     */
+    boolean hasValue();
+
+    /**
+     * Return a String representation of the field path as described in
+     * {@link ClientGraphQlResponse#field(String)}.
+     */
+    String getPath();
+
+    /**
+     * Return a parsed representation of the field path, in the format described
+     * for error paths in Section 7.1.2, "Response Format" of the GraphQL spec.
+     *
+     * @see ResponseError#getParsedPath()
+     */
+    List<Object> getParsedPath();
+
+    /**
+     * Return the raw field value, e.g. Map, List, or a scalar type.
+     *
+     * @param <T> the expected value type to cast to
+     * @return the value
+     */
+    @Nullable
+    <T> T getValue();
+
+    /**
+     * Return the error that provides the reason for a failed field.
+     * <p>When the field <strong>does not</strong> {@link #hasValue() have} a
+     * value, this method looks for the first field error. According to the
+     * GraphQL spec, section 6.4.4, "Handling Field Errors", there should be
+     * only one error per field. The returned field error may be:
+     * <ul>
+     * <li>on the field
+     * <li>on a parent field, when the field is not present
+     * <li>on a nested field, when a {@code non-null} nested field error bubbles up
+     * </ul>
+     * <p>As a fallback, this method also checks "request errors" in case the
+     * entire response is not {@link GraphQlResponse#isValid() valid}. If there
+     * are no errors at all, {@code null} is returned, and it implies the field
+     * value was set to {@code null} by its {@code DataFetcher}.
+     * <p>When the field <strong>does</strong> have a value, it is considered
+     * valid and this method returns {@code null}, although the field may be
+     * partial and contain {@link #getErrors() errors} on nested fields.
+     *
+     * @return return the error for this field, or {@code null} if there is no
+     * error with the same path as the field path
+     */
+    @Nullable
+    ResponseError getError();
+
+    /**
+     * Return all field errors including errors above, at, and below this field.
+     * <p>In practice, when the field <strong>does have</strong> a value, it is
+     * considered valid but possibly partial with nested field errors. When the
+     * field <strong>does not have</strong> a value, there should be only one
+     * field error, and in that case it is better to use {@link #getError()}.
+     */
+    List<ResponseError> getErrors();
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlHandler.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlHandler.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.solon.execution.ThreadLocalAccessor;
+import java.util.List;
+import org.noear.solon.lang.Nullable;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * Contract for common handling of a GraphQL request over HTTP or WebSocket,
+ * for use with Spring MVC or Spring WebFlux.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface WebGraphQlHandler {
+
+    /**
+     * Return the single interceptor of type
+     * {@link WebSocketGraphQlInterceptor} among all the configured
+     * interceptors.
+     */
+    WebSocketGraphQlInterceptor getWebSocketInterceptor();
+
+    /**
+     * Return the composite {@link ThreadLocalAccessor} that the handler is
+     * configured with.
+     */
+    @Nullable
+    ThreadLocalAccessor getThreadLocalAccessor();
+
+    /**
+     * Execute the given request and return the response.
+     *
+     * @param request the request to execute
+     * @return the response
+     */
+    Mono<WebGraphQlResponse> handleRequest(WebGraphQlRequest request);
+
+
+    /**
+     * Provides access to a builder to create a {@link WebGraphQlHandler} instance.
+     *
+     * @param graphQlService the {@link ExecutionGraphQlService} to use for actual execution of the
+     * request.
+     * @return a builder for a WebGraphQlHandler
+     */
+    static Builder builder(ExecutionGraphQlService graphQlService) {
+        return new DefaultWebGraphQlHandlerBuilder(graphQlService);
+    }
+
+
+    /**
+     * Builder for a {@link WebGraphQlHandler} that executes a
+     * {@link WebGraphQlInterceptor} chain followed by a
+     * {@link ExecutionGraphQlService}.
+     */
+    interface Builder {
+
+        /**
+         * Configure interceptors to be invoked before the target
+         * {@code GraphQlService}.
+         * <p>One of the interceptors can be of type
+         * {@link WebSocketGraphQlInterceptor} to handle data from the
+         * first {@code ConnectionInit} message expected on a GraphQL over
+         * WebSocket session, as well as the {@code Complete} message expected
+         * at the end of a session.
+         *
+         * @param interceptors the interceptors to add
+         * @return this builder
+         */
+        Builder interceptor(WebGraphQlInterceptor... interceptors);
+
+        /**
+         * Alternative to {@link #interceptor(WebGraphQlInterceptor...)}
+         * with a List.
+         *
+         * @param interceptors the list of interceptors to add
+         * @return this builder
+         */
+        Builder interceptors(List<WebGraphQlInterceptor> interceptors);
+
+        /**
+         * Configure accessors for ThreadLocal variables to use to extract
+         * ThreadLocal values at the start of GraphQL execution in the web layer,
+         * and have those saved, and restored around the invocation of data
+         * fetchers and exception resolvers.
+         *
+         * @param accessors the accessors to add
+         * @return this builder
+         */
+        Builder threadLocalAccessor(ThreadLocalAccessor... accessors);
+
+        /**
+         * Alternative to {@link #threadLocalAccessor(ThreadLocalAccessor...)} with a
+         * List.
+         *
+         * @param accessors the list of accessors to add
+         * @return this builder
+         */
+        Builder threadLocalAccessors(List<ThreadLocalAccessor> accessors);
+
+        /**
+         * Build the {@link WebGraphQlHandler} instance.
+         *
+         * @return the built WebGraphQlHandler
+         */
+        WebGraphQlHandler build();
+
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlHandlerGetter.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlHandlerGetter.java
@@ -1,0 +1,18 @@
+package graphql.solon.support;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+public class WebGraphQlHandlerGetter {
+
+    private WebGraphQlHandler graphQlHandler;
+
+    public void setGraphQlHandler(WebGraphQlHandler graphQlHandler) {
+        this.graphQlHandler = graphQlHandler;
+    }
+
+    public WebGraphQlHandler getGraphQlHandler() {
+        return this.graphQlHandler;
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlInterceptor.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlInterceptor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * Interceptor for server handling of GraphQL over HTTP or WebSocket requests,
+ * providing access to info about the underlying HTTP request or WebSocket
+ * handshake, and allowing customization of the {@link ExecutionInput} and
+ * the {@link ExecutionResult}.
+ *
+ * <p>Interceptors are typically declared as beans in Spring configuration and
+ * ordered as defined in {@link ObjectProvider#orderedStream()}.
+ *
+ * <p>Supported for Spring MVC and WebFlux.
+ *
+ * @author Rossen Stoyanchev
+ * @see WebSocketGraphQlInterceptor
+ * @since 1.0.0
+ */
+public interface WebGraphQlInterceptor {
+
+    /**
+     * Intercept a request and delegate to the rest of the chain including other
+     * interceptors and a {@link ExecutionGraphQlService}.
+     *
+     * @param request the request which may be a {@link WebSocketGraphQlRequest}
+     * when intercepting a GraphQL request over WebSocket
+     * @param chain the rest of the chain to execute the request
+     * @return a {@link Mono} with the response
+     */
+    Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain);
+
+    /**
+     * Return a new {@link WebGraphQlInterceptor} that invokes the current
+     * interceptor first and then the one that is passed in.
+     *
+     * @param nextInterceptor the interceptor to delegate to after the current
+     * @return a new interceptor that chains the two
+     */
+    default WebGraphQlInterceptor andThen(WebGraphQlInterceptor nextInterceptor) {
+        return (request, chain) -> intercept(request, nextRequest -> {
+            return nextInterceptor.intercept(nextRequest, chain);
+        });
+    }
+
+    /**
+     * Apply this interceptor to the given {@code Chain} resulting in an intercepted chain.
+     *
+     * @param chain the chain to add interception around
+     * @return a new chain instance
+     */
+    default Chain apply(Chain chain) {
+        return request -> intercept(request, chain);
+    }
+
+
+    /**
+     * Contract for delegation to the rest of the chain.
+     */
+    interface Chain {
+
+        /**
+         * Delegate to the rest of the chain to execute the request.
+         *
+         * @param request the request to execute
+         * the {@link ExecutionInput} for {@link graphql.GraphQL}.
+         * @return {@code Mono} with the response
+         */
+        Mono<WebGraphQlResponse> next(WebGraphQlRequest request);
+
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.solon.util.Assert;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * {@link org.springframework.graphql.GraphQlRequest} implementation for server
+ * handling over HTTP or WebSocket. Provides access to the URL and headers of
+ * the underlying request. For WebSocket, these are the URL and headers of the
+ * HTTP handshake request.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest implements
+    ExecutionGraphQlRequest {
+
+    private static final Map<String, List<HttpCookie>> EMPTY_COOKIES = new HashMap<>();
+
+    private final URI uri;
+
+    private final Map<String, List<String>> headers;
+
+    private final Map<String, List<HttpCookie>> cookies;
+
+    private final Map<String, Object> attributes;
+
+
+    /**
+     * Create an instance.
+     *
+     * @deprecated as of 1.1.3 in favor of the constructor with cookies
+     */
+    @Deprecated
+    public WebGraphQlRequest(URI uri, Map<String, List<String>> headers, Map<String, Object> body,
+        String id,
+        @Nullable Locale locale) {
+        this(uri, headers, null, Collections.emptyMap(), body, id, locale);
+    }
+
+    /**
+     * Create an instance.
+     *
+     * @param uri the URL for the HTTP request or WebSocket handshake
+     * @param headers the HTTP request headers
+     * @param cookies the HTTP request cookies
+     * @param attributes request attributes
+     * @param body the deserialized content of the GraphQL request
+     * @param id an identifier for the GraphQL request
+     * @param locale the locale from the HTTP request, if any
+     * @since 1.1.3
+     */
+    public WebGraphQlRequest(
+        URI uri, Map<String, List<String>> headers, @Nullable Map<String, List<HttpCookie>> cookies,
+        Map<String, Object> attributes, Map<String, Object> body, String id,
+        @Nullable Locale locale) {
+        super(getKey("query", body), getKey("operationName", body), getKey("variables", body),
+            getKey("extensions", body), id, locale);
+
+        Assert.notNull(uri, "URI is required'");
+        Assert.notNull(headers, "HttpHeaders is required'");
+
+        this.uri = uri;
+        this.headers = headers;
+        this.cookies = (cookies != null ? Collections.unmodifiableMap(cookies)
+            : EMPTY_COOKIES);
+        this.attributes = Collections.unmodifiableMap(attributes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getKey(String key, Map<String, Object> body) {
+        if (key.equals("query") && StringUtils.isBlank((String) body.get(key))) {
+            throw new IllegalStateException("No \"query\" in the request document");
+        }
+        return (T) body.get(key);
+    }
+
+
+    /**
+     * Return the URL for the HTTP request or WebSocket handshake.
+     */
+    public URI getUri() {
+        return this.uri;
+    }
+
+    /**
+     * Return the HTTP headers of the request or WebSocket handshake.
+     */
+    public Map<String, List<String>> getHeaders() {
+        return this.headers;
+    }
+
+    /**
+     * Return the cookies of the request of WebSocket handshake.
+     *
+     * @since 1.1.3
+     */
+    public Map<String, List<HttpCookie>> getCookies() {
+        return this.cookies;
+    }
+
+    /**
+     * Return the request or WebSocket session attributes.
+     *
+     * @since 1.1.3
+     */
+    public Map<String, Object> getAttributes() {
+        return this.attributes;
+    }
+
+}
+

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlResponse.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebGraphQlResponse.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.support;
+
+import graphql.ExecutionResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+
+/**
+ * {@link org.springframework.graphql.GraphQlResponse} implementation for server
+ * handling over HTTP or over WebSocket.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public class WebGraphQlResponse extends DefaultExecutionGraphQlResponse {
+
+    private final Map<String, List<String>> responseHeaders;
+
+
+    /**
+     * Create an instance that wraps the given {@link ExecutionGraphQlResponse}.
+     *
+     * @param response the response to wrap
+     */
+    public WebGraphQlResponse(ExecutionGraphQlResponse response) {
+        super(response);
+        this.responseHeaders = new HashMap<>();
+    }
+
+    private WebGraphQlResponse(WebGraphQlResponse original, ExecutionResult executionResult) {
+        super(original.getExecutionInput(), executionResult);
+        this.responseHeaders = original.getResponseHeaders();
+    }
+
+
+    /**
+     * Return the headers to be added to the HTTP response.
+     * <p>By default, this is empty.
+     * <p><strong>Note:</strong> This is for use with GraphQL over HTTP requests
+     * but not for GraphQL over WebSocket where the initial handshake HTTP
+     * request completes before queries begin.
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return this.responseHeaders;
+    }
+
+    /**
+     * Transform the underlying {@link ExecutionResult} through a {@link Builder}
+     * and return a new instance with the modified values.
+     *
+     * @param consumer callback to transform the result
+     * @return the new response instance with the mutated {@code ExecutionResult}
+     */
+    public WebGraphQlResponse transform(Consumer<Builder> consumer) {
+        Builder builder = new Builder(this);
+        consumer.accept(builder);
+        return builder.build();
+    }
+
+
+    /**
+     * Builder to transform a {@link WebGraphQlResponse}.
+     */
+    public static final class Builder extends
+        DefaultExecutionGraphQlResponse.Builder<Builder, WebGraphQlResponse> {
+
+        private Builder(WebGraphQlResponse original) {
+            super(original);
+        }
+
+        @Override
+        protected WebGraphQlResponse build(WebGraphQlResponse original, ExecutionResult newResult) {
+            return new WebGraphQlResponse(original, newResult);
+        }
+
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebSocketGraphQlInterceptor.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/support/WebSocketGraphQlInterceptor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package graphql.solon.support;
+
+import graphql.solon.ws.support.WebSocketSessionInfo;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+
+/**
+ * An extension of {@link WebGraphQlInterceptor} with additional methods
+ * to handle the start and end of a WebSocket connection.
+ *
+ * <p>Use {@link WebGraphQlHandler.Builder#interceptor(WebGraphQlInterceptor...)}
+ * to configure the interceptor chain. Only one interceptor in the chain may be
+ * of type {@code WebSocketGraphQlInterceptor}.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface WebSocketGraphQlInterceptor extends WebGraphQlInterceptor {
+
+    @Override
+    default Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
+        return chain.next(request);
+    }
+
+    /**
+     * Handle the {@code "connection_init"} message at the start of a GraphQL over
+     * WebSocket session and return an optional payload for the
+     * {@code "connection_ack"} message to send back.
+     *
+     * @param sessionInfo information about the underlying WebSocket session
+     * @param connectionInitPayload the payload from the {@code "connection_init"} message
+     * @return the payload for the {@code "connection_ack"}, or empty
+     */
+    default Mono<Object> handleConnectionInitialization(
+        WebSocketSessionInfo sessionInfo, Map<String, Object> connectionInitPayload) {
+
+        return Mono.empty();
+    }
+
+    /**
+     * Handle the {@code "complete"} message that a client sends to stop a
+     * subscription stream. The underlying {@link org.reactivestreams.Publisher}
+     * for the subscription is automatically cancelled. This callback is for any
+     * additional, or more centralized handling across subscriptions.
+     *
+     * @param sessionInfo information about the underlying WebSocket session
+     * @param subscriptionId the unique id for the subscription; correlates to the
+     * {@link WebGraphQlRequest#getId() requestId} from the {@code "subscribe"}
+     * message that started the subscription stream
+     * @return {@code Mono} for the completion of handling
+     */
+    default Mono<Void> handleCancelledSubscription(WebSocketSessionInfo sessionInfo,
+        String subscriptionId) {
+        return Mono.empty();
+    }
+
+    /**
+     * Invoked when the WebSocket session is closed, from either side.
+     *
+     * @param sessionInfo information about the underlying WebSocket session
+     * @param statusCode the WebSocket "close" status code
+     * @param connectionInitPayload the payload from the {@code "connect_init"}
+     * message received at the start of the connection
+     */
+    default void handleConnectionClosed(
+        WebSocketSessionInfo sessionInfo,
+        Map<String, Object> connectionInitPayload) {
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/GraphqlWebsocket.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/GraphqlWebsocket.java
@@ -1,0 +1,318 @@
+package graphql.solon.ws;
+
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.solon.support.WebGraphQlHandler;
+import graphql.solon.support.WebGraphQlHandlerGetter;
+import graphql.solon.support.WebGraphQlResponse;
+import graphql.solon.support.WebSocketGraphQlInterceptor;
+import graphql.solon.util.Assert;
+import graphql.solon.ws.support.GraphQlWebSocketMessage;
+import graphql.solon.ws.support.WebSocketGraphQlRequest;
+import graphql.solon.ws.support.WebSocketSessionInfo;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.collections.CollectionUtils;
+import org.noear.snack.ONode;
+import org.noear.solon.annotation.Inject;
+import org.noear.solon.lang.Nullable;
+import org.noear.solon.net.annotation.ServerEndpoint;
+import org.noear.solon.net.websocket.WebSocket;
+import org.noear.solon.net.websocket.listener.SimpleWebSocketListener;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+@ServerEndpoint("/graphql")
+public class GraphqlWebsocket extends SimpleWebSocketListener {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphqlWebsocket.class);
+
+    private final Map<String, SessionState> sessionInfoMap = new ConcurrentHashMap<>();
+
+    @Inject
+    private WebGraphQlHandlerGetter getter;
+
+    @Override
+    public void onOpen(WebSocket socket) {
+        SessionState sessionState = new SessionState(socket.id(),
+            new WebMvcSessionInfo(socket));
+        this.sessionInfoMap.put(socket.id(), sessionState);
+    }
+
+    @Override
+    public void onClose(WebSocket socket) {
+        SessionState state = this.sessionInfoMap.remove(socket.id());
+        if (Objects.nonNull(state)) {
+            state.dispose();
+
+            Map<String, Object> connectionInitPayload = state.getConnectionInitPayload();
+            if (connectionInitPayload != null) {
+                WebGraphQlHandler graphQlHandler = this.getter.getGraphQlHandler();
+                WebSocketGraphQlInterceptor webSocketInterceptor = graphQlHandler
+                    .getWebSocketInterceptor();
+                webSocketInterceptor.handleConnectionClosed(
+                    state.getSessionInfo(), connectionInitPayload);
+            }
+        }
+    }
+
+    @Override
+    public void onError(WebSocket socket, Throwable error) {
+        SessionState state = this.sessionInfoMap.remove(socket.id());
+        if (Objects.nonNull(state)) {
+            state.dispose();
+        }
+
+    }
+
+    @Override
+    public void onMessage(WebSocket socket, String text) throws IOException {
+        GraphQlWebSocketMessage graphQlWebSocketMessage = ONode.loadStr(text)
+            .toObject(GraphQlWebSocketMessage.class);
+        String id = graphQlWebSocketMessage.getId();
+        SessionState state = getSessionInfo(socket);
+
+        switch (graphQlWebSocketMessage.resolvedType()) {
+            case CONNECTION_INIT:
+                GraphQlWebSocketMessage respMessage = GraphQlWebSocketMessage
+                    .connectionAck(Collections.emptyMap());
+                String respStr = ONode.stringify(respMessage);
+                socket.send(respStr);
+                break;
+            case SUBSCRIBE:
+                if (Objects.isNull(id)) {
+                    socket.close();
+                }
+                String url = socket.url();
+                URI uri = URI.create(url);
+                Map<String, Object> payload = (Map<String, Object>) graphQlWebSocketMessage
+                    .getPayload();
+                WebSocketGraphQlRequest request = new WebSocketGraphQlRequest(uri,
+                    Collections.emptyMap(), payload, id,
+                    Locale.getDefault(), state.sessionInfo);
+                this.getter.getGraphQlHandler().handleRequest(request)
+                    .flatMapMany(resp -> this.handleResponse(socket, id, resp))
+                    .subscribe(new SendMessageSubscriber(id, socket, state));
+                break;
+            case COMPLETE:
+                if (Objects.nonNull(id)) {
+                    Subscription subscription = state.getSubscriptions().remove(id);
+                    if (Objects.nonNull(subscription)) {
+                        subscription.cancel();
+                    }
+                    WebGraphQlHandler graphQlHandler = this.getter.getGraphQlHandler();
+                    WebSocketGraphQlInterceptor webSocketInterceptor = graphQlHandler
+                        .getWebSocketInterceptor();
+                    webSocketInterceptor.handleCancelledSubscription(
+                        state.getSessionInfo(), id).block(Duration.ofSeconds(10));
+                }
+                break;
+            case PING:
+                socket.send(ONode.stringify(GraphQlWebSocketMessage
+                    .pong(null)));
+                break;
+            default:
+                socket.close();
+        }
+    }
+
+    private static class SendMessageSubscriber extends BaseSubscriber<String> {
+
+        private final String subscriptionId;
+
+        private final WebSocket session;
+
+        private final SessionState sessionState;
+
+        SendMessageSubscriber(String subscriptionId, WebSocket session, SessionState sessionState) {
+            this.subscriptionId = subscriptionId;
+            this.session = session;
+            this.sessionState = sessionState;
+        }
+
+        @Override
+        protected void hookOnSubscribe(Subscription subscription) {
+            subscription.request(1);
+        }
+
+        @Override
+        protected void hookOnNext(String nextMessage) {
+            this.session.send(nextMessage);
+            request(1);
+        }
+
+        @Override
+        public void hookOnError(Throwable ex) {
+            this.tryCloseWithError(this.session, ex, log);
+        }
+
+        @Override
+        public void hookOnComplete() {
+            this.sessionState.getSubscriptions().remove(this.subscriptionId);
+        }
+
+        public void tryCloseWithError(WebSocket session, Throwable exception, Logger logger) {
+            if (logger.isErrorEnabled()) {
+                logger.error("Closing session due to exception for " + session, exception);
+            }
+            if (session.isValid()) {
+                try {
+                    session.close();
+                } catch (Throwable ex) {
+                    // ignore
+                }
+            }
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private Flux<String> handleResponse(WebSocket session, String id, WebGraphQlResponse response) {
+        if (log.isDebugEnabled()) {
+            log.debug("Execution result ready"
+                + (!CollectionUtils.isEmpty(response.getErrors()) ? " with errors: " + response
+                .getErrors() : "")
+                + ".");
+        }
+        Flux<Map<String, Object>> responseFlux;
+        if (response.getData() instanceof Publisher) {
+            // Subscription
+            responseFlux = Flux.from((Publisher<ExecutionResult>) response.getData())
+                .map(ExecutionResult::toSpecification)
+                .doOnSubscribe((subscription) -> {
+                    Subscription prev = getSessionInfo(session).getSubscriptions()
+                        .putIfAbsent(id, subscription);
+                    if (prev != null) {
+                        throw new SubscriptionExistsException();
+                    }
+                });
+        } else {
+            // Single response (query or mutation) that may contain errors
+            responseFlux = Flux.just(response.toMap());
+        }
+
+        return responseFlux
+            .map(responseMap -> ONode.stringify(GraphQlWebSocketMessage.next(id, responseMap)))
+            .concatWith(
+                Mono.fromCallable(() -> ONode.stringify(GraphQlWebSocketMessage.complete(id))))
+            .onErrorResume((ex) -> {
+                if (ex instanceof SubscriptionExistsException) {
+                    session.close();
+                    return Flux.empty();
+                }
+                String message = ex.getMessage();
+                GraphQLError error = GraphqlErrorBuilder.newError().message(message).build();
+                return Mono.just(ONode.stringify(GraphQlWebSocketMessage.error(id, error)));
+            });
+    }
+
+    private SessionState getSessionInfo(WebSocket session) {
+        SessionState info = this.sessionInfoMap.get(session.id());
+        Assert.notNull(info, "No SessionInfo for " + session);
+        return info;
+    }
+
+    private static class WebMvcSessionInfo implements WebSocketSessionInfo {
+
+        private final WebSocket session;
+
+        private WebMvcSessionInfo(WebSocket session) {
+            this.session = session;
+        }
+
+        @Override
+        public String getId() {
+            return this.session.id();
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return this.session.attrMap();
+        }
+
+        @Override
+        public URI getUri() {
+            return URI.create(this.session.url());
+        }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() throws IOException {
+            return this.session.remoteAddress();
+        }
+    }
+
+    private static class SessionState {
+
+        private final WebSocketSessionInfo sessionInfo;
+
+        private final AtomicReference<Map<String, Object>> connectionInitPayloadRef = new AtomicReference<>();
+
+        private final Map<String, Subscription> subscriptions = new ConcurrentHashMap<>();
+
+        private final Scheduler scheduler;
+
+        SessionState(String graphQlSessionId, WebSocketSessionInfo sessionInfo) {
+            this.sessionInfo = sessionInfo;
+            this.scheduler = Schedulers.newSingle("GraphQL-WsSession-" + graphQlSessionId);
+        }
+
+        public WebSocketSessionInfo getSessionInfo() {
+            return this.sessionInfo;
+        }
+
+        @Nullable
+        Map<String, Object> getConnectionInitPayload() {
+            return this.connectionInitPayloadRef.get();
+        }
+
+        boolean setConnectionInitPayload(Map<String, Object> payload) {
+            return this.connectionInitPayloadRef.compareAndSet(null, payload);
+        }
+
+
+        Map<String, Subscription> getSubscriptions() {
+            return this.subscriptions;
+        }
+
+        void dispose() {
+            for (Map.Entry<String, Subscription> entry : this.subscriptions.entrySet()) {
+                try {
+                    entry.getValue().cancel();
+                } catch (Throwable ex) {
+                    // Ignore and keep on
+                }
+            }
+            this.subscriptions.clear();
+            this.scheduler.dispose();
+        }
+
+        Scheduler getScheduler() {
+            return this.scheduler;
+        }
+
+    }
+
+    class SubscriptionExistsException extends RuntimeException {
+
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/GraphQlWebSocketMessage.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/GraphQlWebSocketMessage.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.ws.support;
+
+import graphql.GraphQLError;
+import graphql.solon.util.Assert;
+import graphql.solon.util.ObjectUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * Represents a GraphQL over WebSocket protocol message.
+ *
+ * @author Rossen Stoyanchev
+ * @see <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md">GraphQL Over WebSocket Protocol</a>
+ * @since 1.0.0
+ */
+public class GraphQlWebSocketMessage {
+
+	@Nullable
+	private String id;
+
+	@Nullable
+	private GraphQlWebSocketMessageType type;
+
+	@Nullable
+	private Object payload;
+
+
+	/**
+	 * Private constructor. See static factory methods.
+	 */
+	private GraphQlWebSocketMessage(@Nullable String id, GraphQlWebSocketMessageType type,
+		@Nullable Object payload) {
+		Assert.notNull(type, "GraphQlMessageType is required");
+		Assert.isTrue(payload != null || type.doesNotRequirePayload(),
+			"Payload is required for [" + type + "]");
+		this.id = id;
+		this.type = type;
+		this.payload = payload;
+	}
+
+
+	/**
+	 * Constructor for deserialization.
+	 */
+	public GraphQlWebSocketMessage() {
+		this.type = GraphQlWebSocketMessageType.NOT_SPECIFIED;
+	}
+
+
+	/**
+	 * Return the request id that is applicable to messages associated with a
+	 * request, or {@code null} for connection level messages.
+	 */
+	@Nullable
+	public String getId() {
+		return this.id;
+	}
+
+	/**
+	 * Return the message type value as it should appear on the wire.
+	 */
+	public String getType() {
+		Assert.notNull(this.type, "Type is required");
+		return this.type.value();
+	}
+
+	/**
+	 * Return the message type as an emum.
+	 */
+	public GraphQlWebSocketMessageType resolvedType() {
+		Assert.state(this.type != null, "GraphQlWebSocketMessage does not have a type");
+		return this.type;
+	}
+
+	/**
+	 * Return the payload. For a deserialized message, this is typically a
+	 * {@code Map} or {@code List} for an {@code "error"} message.
+	 */
+	@SuppressWarnings("unchecked")
+	public <P> P getPayload() {
+		if (this.payload == null) {
+			Assert.state(resolvedType().doesNotRequirePayload(), this.type + " requires a payload");
+			return (P) Collections.emptyMap();
+		}
+		return (P) this.payload;
+	}
+
+	public void setId(@Nullable String id) {
+		this.id = id;
+	}
+
+	public void setType(String type) {
+		this.type = GraphQlWebSocketMessageType.fromValue(type);
+	}
+
+	public void setPayload(@Nullable Object payload) {
+		this.payload = payload;
+	}
+
+
+	@Override
+	public int hashCode() {
+		int hashCode = (this.type != null ? this.type.hashCode() : 0);
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode(this.id);
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode(this.payload);
+		return hashCode;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof GraphQlWebSocketMessage)) {
+			return false;
+		}
+		GraphQlWebSocketMessage other = (GraphQlWebSocketMessage) o;
+		return (ObjectUtils.nullSafeEquals(this.type, other.type) &&
+			(ObjectUtils.nullSafeEquals(this.id, other.id) || (this.id == null && other.id == null))
+			&&
+			(ObjectUtils.nullSafeEquals(getPayload(), other.getPayload())));
+	}
+
+	@Override
+	public String toString() {
+		return "GraphQlWebSocketMessage[" +
+			(this.id != null ? "id=\"" + this.id + "\"" + ", " : "") +
+			"type=\"" + this.type + "\"" +
+			(this.payload != null ? ", payload=" + this.payload : "") + "]";
+	}
+
+
+	/**
+	 * Create a {@code "connection_init"} client message.
+	 *
+	 * @param payload an optional payload
+	 */
+	public static GraphQlWebSocketMessage connectionInit(@Nullable Object payload) {
+		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.CONNECTION_INIT,
+			payload);
+	}
+
+	/**
+	 * Create a {@code "connection_ack"} server message.
+	 *
+	 * @param payload an optional payload
+	 */
+	public static GraphQlWebSocketMessage connectionAck(@Nullable Object payload) {
+		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.CONNECTION_ACK,
+			payload);
+	}
+
+	/**
+	 * Create a {@code "subscribe"} client message.
+	 *
+	 * @param id unique request id
+	 * @param request the request to add as the message payload
+	 */
+//	public static GraphQlWebSocketMessage subscribe(String id, GraphQlRequest request) {
+//		Assert.notNull(request, "GraphQlRequest is required");
+//		return new GraphQlWebSocketMessage(id, GraphQlWebSocketMessageType.SUBSCRIBE,
+//			request.toMap());
+//	}
+
+	/**
+	 * Create a {@code "next"} server message.
+	 *
+	 * @param id unique request id
+	 * @param responseMap the response map
+	 */
+	public static GraphQlWebSocketMessage next(String id, Map<String, Object> responseMap) {
+		Assert.notNull(responseMap, "'responseMap' is required");
+		return new GraphQlWebSocketMessage(id, GraphQlWebSocketMessageType.NEXT, responseMap);
+	}
+
+	/**
+	 * Create an {@code "error"} server message.
+	 *
+	 * @param id unique request id
+	 * @param error the error to add as the message payload
+	 */
+	public static GraphQlWebSocketMessage error(String id, GraphQLError error) {
+		Assert.notNull(error, "GraphQlError is required");
+		List<Map<String, Object>> errors = Collections.singletonList(error.toSpecification());
+		return new GraphQlWebSocketMessage(id, GraphQlWebSocketMessageType.ERROR, errors);
+	}
+
+	/**
+	 * Create a {@code "complete"} server message.
+	 *
+	 * @param id unique request id
+	 */
+	public static GraphQlWebSocketMessage complete(String id) {
+		return new GraphQlWebSocketMessage(id, GraphQlWebSocketMessageType.COMPLETE, null);
+	}
+
+	/**
+	 * Create a {@code "ping"} client or server message.
+	 *
+	 * @param payload an optional payload
+	 */
+	public static GraphQlWebSocketMessage ping(@Nullable Object payload) {
+		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.PING, payload);
+	}
+
+	/**
+	 * Create a {@code "pong"} client or server message.
+	 *
+	 * @param payload an optional payload
+	 */
+	public static GraphQlWebSocketMessage pong(@Nullable Object payload) {
+		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.PONG, payload);
+	}
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/GraphQlWebSocketMessageType.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/GraphQlWebSocketMessageType.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.ws.support;
+
+
+import org.noear.snack.annotation.ONodeAttr;
+
+/**
+ * copy from {@link org.springframework.graphql.server.support.GraphQlWebSocketMessageType}
+ *
+ * Enum for a message type as defined in the GraphQL over WebSocket spec proposal.
+ *
+ * @author Rossen Stoyanchev
+ * @see <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md">GraphQL Over WebSocket Protocol</a>
+ * @since 1.0.0
+ */
+public enum GraphQlWebSocketMessageType {
+
+	CONNECTION_INIT("connection_init", false),
+
+	CONNECTION_ACK("connection_ack", false),
+
+	PING("ping", false),
+
+	PONG("pong", false),
+
+	SUBSCRIBE("subscribe", true),
+
+	NEXT("next", true),
+
+	ERROR("error", true),
+
+	COMPLETE("complete", false),
+
+	/**
+	 * Indicates the GraphQL message did not have a message type.
+	 */
+	NOT_SPECIFIED("", false);
+
+
+	private static final GraphQlWebSocketMessageType[] VALUES;
+
+	static {
+		VALUES = values();
+	}
+
+
+	@ONodeAttr
+	private final String value;
+
+	private final boolean requiresPayload;
+
+
+	GraphQlWebSocketMessageType(String value, boolean requiresPayload) {
+		this.value = value;
+		this.requiresPayload = requiresPayload;
+	}
+
+
+	/**
+	 * The protocol value for the message type.
+	 */
+	public String value() {
+		return this.value;
+	}
+
+	/**
+	 * Return {@code } if the message type has a payload, and it is required.
+	 */
+	public boolean doesNotRequirePayload() {
+		return !this.requiresPayload;
+	}
+
+
+	public static GraphQlWebSocketMessageType fromValue(String value) {
+		for (GraphQlWebSocketMessageType type : VALUES) {
+			if (type.value.equals(value)) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("No matching constant for [" + value + "]");
+	}
+
+
+	@Override
+	public String toString() {
+		return this.value;
+	}
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/WebSocketGraphQlRequest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/WebSocketGraphQlRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql.solon.ws.support;
+
+
+import graphql.solon.support.WebGraphQlRequest;
+import graphql.solon.util.Assert;
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+
+/**
+ * {@link org.springframework.graphql.server.WebGraphQlRequest} extension for
+ * server handling of GraphQL over WebSocket requests.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public class WebSocketGraphQlRequest extends WebGraphQlRequest {
+
+    private final WebSocketSessionInfo sessionInfo;
+
+
+    /**
+     * Create an instance.
+     *
+     * @param uri the URL for the HTTP request or WebSocket handshake
+     * @param headers the HTTP request headers
+     * @param body the deserialized content of the GraphQL request
+     * @param id the id from the GraphQL over WebSocket {@code "subscribe"} message
+     * @param locale the locale from the HTTP request, if any
+     * @param sessionInfo the WebSocket session id
+     */
+    public WebSocketGraphQlRequest(
+        URI uri, Map<String, List<String>> headers, Map<String, Object> body, String id,
+        @Nullable Locale locale,
+        WebSocketSessionInfo sessionInfo) {
+
+        super(uri, headers, body, id, locale);
+        Assert.notNull(sessionInfo, "WebSocketSessionInfo is required");
+        this.sessionInfo = sessionInfo;
+    }
+
+
+    /**
+     * Return information about the underlying WebSocket session.
+     */
+    public WebSocketSessionInfo getSessionInfo() {
+        return this.sessionInfo;
+    }
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/WebSocketSessionInfo.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/ws/support/WebSocketSessionInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package graphql.solon.ws.support;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Map;
+import org.noear.solon.lang.Nullable;
+
+/**
+ * copy from {@link org.springframework.graphql.server.WebSocketSessionInfo}
+ *
+ * Expose information about the underlying WebSocketSession including the
+ * session id, the attributes, and HTTP handshake request.
+ *
+ * @author Rossen Stoyanchev
+ * @since 1.0.0
+ */
+public interface WebSocketSessionInfo {
+
+    /**
+     * Return the id for the WebSocketSession.
+     */
+    String getId();
+
+    /**
+     * Return the map with attributes associated with the WebSocket session.
+     */
+    Map<String, Object> getAttributes();
+
+    /**
+     * Return the URL for the WebSocket endpoint.
+     */
+    URI getUri();
+
+    /**
+     * Return the HTTP headers from the handshake request.
+     */
+    // Map<String, String> getHeaders();
+
+    /**
+     * Return the principal associated with the handshake request, if any.
+     */
+    //Mono<Principal> getPrincipal();
+
+    /**
+     * For a server session this is the remote address where the handshake
+     * request came from. For a client session, it is {@code null}.
+     */
+    @Nullable
+    InetSocketAddress getRemoteAddress() throws Exception;
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/resources/WEB-INF/view/index.html
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/resources/WEB-INF/view/index.html
@@ -20,7 +20,7 @@
 
 <body>
 <div id="graphiql">Loading...</div>
-<script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
+<script src="https://unpkg.com/graphiql/graphiql.js" type="application/javascript"></script>
 <script>
     const params = new URLSearchParams(window.location.search);
 

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
@@ -12,7 +12,7 @@ public class App {
 
     public static void main(String[] args) {
         Solon.start(App.class, args, app -> {
-            app.enableWebSocket(true);
+            app.enableWebSocket(false);
         });
     }
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
@@ -1,4 +1,4 @@
-package test;
+package demo;
 
 import org.noear.solon.Solon;
 import org.noear.solon.annotation.Import;

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
@@ -12,9 +12,7 @@ public class App {
 
     public static void main(String[] args) {
         Solon.start(App.class, args, app -> {
-//            SolonProps cfg = app.cfg();
-//            String tbk = cfg.get("tbk");
-//            app.context().beanScan("demo.book.component");
+            app.enableWebSocket(true);
         });
     }
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/dto/ProductPriceHistoryDTO.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/dto/ProductPriceHistoryDTO.java
@@ -1,0 +1,43 @@
+package demo.product.dto;
+
+import java.util.Date;
+
+public class ProductPriceHistoryDTO {
+
+    private Long id;
+    private Date startDate;
+    private int price;
+
+    public ProductPriceHistoryDTO() {
+    }
+
+    public ProductPriceHistoryDTO(Long id, Date startDate, int price) {
+        this.id = id;
+        this.startDate = startDate;
+        this.price = price;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/support/ProductService.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/support/ProductService.java
@@ -1,0 +1,39 @@
+package demo.product.support;
+
+import demo.product.dto.ProductPriceHistoryDTO;
+import graphql.solon.annotation.SubscriptionMapping;
+import java.util.Date;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.noear.solon.annotation.Component;
+import org.noear.solon.annotation.Param;
+import reactor.core.publisher.Flux;
+
+/**
+ * @author fuzi1996
+ * @since 2.3
+ */
+@Component
+public class ProductService {
+
+    private final Random rn = new Random();
+
+    @SubscriptionMapping("notifyProductPriceChange")
+    public Flux<ProductPriceHistoryDTO> notifyProductPriceChange(@Param Long productId) {
+
+        // A flux is the publisher of data
+        return Flux.fromStream(
+            Stream.generate(() -> {
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                return new ProductPriceHistoryDTO(productId, new Date(),
+                    (int) (rn.nextInt(10) + 1 + productId));
+            }));
+
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/BatchListTest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/BatchListTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.nullValue;
 
+import demo.App;
 import demo.course.entity.Course;
 import java.io.IOException;
 import java.util.List;
@@ -16,7 +17,6 @@ import org.noear.solon.core.util.ResourceUtil;
 import org.noear.solon.test.HttpTester;
 import org.noear.solon.test.SolonJUnit5Extension;
 import org.noear.solon.test.SolonTest;
-import test.App;
 
 /**
  * 测试批量查询

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/IntrospectionQueryTest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/IntrospectionQueryTest.java
@@ -3,6 +3,7 @@ package graphql.solon.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import demo.App;
 import graphql.solon.controller.GraphqlController;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,6 @@ import org.noear.solon.core.util.ResourceUtil;
 import org.noear.solon.test.HttpTester;
 import org.noear.solon.test.SolonJUnit5Extension;
 import org.noear.solon.test.SolonTest;
-import test.App;
 
 /**
  * 测试 IntrospectionQuery 查询

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/QueryTest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/QueryTest.java
@@ -3,6 +3,7 @@ package graphql.solon.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import demo.App;
 import demo.book.component.BookService;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,6 @@ import org.noear.solon.core.util.ResourceUtil;
 import org.noear.solon.test.HttpTester;
 import org.noear.solon.test.SolonJUnit5Extension;
 import org.noear.solon.test.SolonTest;
-import test.App;
 
 /**
  * 测试普通的graphql查询

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/SchemaRequestTest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/SchemaRequestTest.java
@@ -3,6 +3,7 @@ package graphql.solon.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
+import demo.App;
 import graphql.solon.controller.GraphqlController;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.noear.solon.test.HttpTester;
 import org.noear.solon.test.SolonJUnit5Extension;
 import org.noear.solon.test.SolonTest;
-import test.App;
 
 /**
  * 测试 Schema 查询

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/base.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/base.gqls
@@ -1,7 +1,8 @@
 type Query {
-    dummy: Boolean
 }
 
 type Mutation {
-    dummy: Boolean
+}
+
+type Subscription {
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/product.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/product.gqls
@@ -1,0 +1,9 @@
+extend type Subscription {
+    notifyProductPriceChange (productId: ID): ProductPriceHistory
+}
+
+type ProductPriceHistory {
+    id: ID!
+    price: Int!
+    startDate: String!
+}


### PR DESCRIPTION
增加websocket数据订阅功能

已知问题:
- 由于使用的`[smart-http](https://github.com/smartboot/smart-http)`无法自定义websocket返回头,因此与`graphiql`存在兼容问题,详见问题 https://github.com/smartboot/smart-http/issues/2
- 关闭`websocket`后,并没有触发`smart-http`的close方法,导致订阅没有被及时取消,但是这个问题我在`spring-graphql`上也复现了,因此生产使用要慎重