### PR TITLE
增加Mutation类型测试，修复传参问题

### DIFF
--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/pom.xml
@@ -71,6 +71,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.noear</groupId>
             <artifactId>solon.view.thymeleaf</artifactId>
             <scope>test</scope>
@@ -98,6 +103,13 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>java-websocket-ns</artifactId>
+            <version>1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/QueryMapping.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/QueryMapping.java
@@ -5,6 +5,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import graphql.solon.constant.OperationType;
 import org.noear.solon.annotation.Alias;
 
 /**
@@ -31,7 +33,7 @@ public @interface QueryMapping {
      * <p>This attributed is supported at the class level and at the method level!
      * When used on both levels, the one on the method level overrides the one at the class level.
      */
-    String typeName() default "Query";
+    String typeName() default OperationType.QUERY;
 
     /**
      * Alias for {@link QueryMapping#field()}.

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMapping.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/annotation/SubscriptionMapping.java
@@ -5,6 +5,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import graphql.language.OperationDefinition;
+import graphql.solon.constant.OperationType;
 import org.noear.solon.annotation.Alias;
 
 /**
@@ -22,5 +25,5 @@ public @interface SubscriptionMapping {
     @Alias("name")
     String value() default "";
 
-    String typeName() default "Subscription";
+    String typeName() default OperationType.SUBSCRIPTION;
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/constant/OperationType.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/constant/OperationType.java
@@ -9,5 +9,6 @@ package graphql.solon.constant;
 public class OperationType {
     public static final String QUERY = "Query";
     public static final String MUTATION = "Mutation";
+    public static final String SUBSCRIPTION = "Subscription";
 
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/constant/OperationType.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/constant/OperationType.java
@@ -1,0 +1,13 @@
+package graphql.solon.constant;
+
+/**
+ * GraphQL 操作类型
+ *
+ * @author lagnx
+ * @since 2.6.6
+ */
+public class OperationType {
+    public static final String QUERY = "Query";
+    public static final String MUTATION = "Mutation";
+
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/controller/GraphqlController.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/controller/GraphqlController.java
@@ -6,6 +6,8 @@ import graphql.GraphQL;
 import graphql.schema.idl.SchemaPrinter;
 import graphql.solon.execution.GraphQlSource;
 import graphql.solon.resource.GraphqlRequestParam;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.noear.solon.annotation.Controller;
@@ -35,9 +37,11 @@ public class GraphqlController {
         ExecutionInput executionInput = ExecutionInput
             .newExecutionInput()
             .query(param.getQuery())
+            .operationName(param.getOperationName() == null ? "" : param.getOperationName())
             .localContext(ctx.getLocale())
             .graphQLContext(mapOfContext)
-                .build();
+            .variables(param.getVariables() == null ? Collections.emptyMap() : param.getVariables())
+            .build();
 
         executionInput = this.graphQlSource.registerDataLoaders(executionInput);
 

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/resolver/argument/ArgumentMethodArgumentResolver.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/main/java/graphql/solon/resolver/argument/ArgumentMethodArgumentResolver.java
@@ -1,5 +1,6 @@
 package graphql.solon.resolver.argument;
 
+import com.alibaba.fastjson.JSON;
 import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
 import java.io.IOException;
@@ -92,7 +93,12 @@ public class ArgumentMethodArgumentResolver implements HandlerMethodArgumentReso
             if (tv == null) {
                 //尝试数据转换
                 try {
+                    // 基础类型的数据转化
                     tv = ConvertUtils.convert(argumentRowValue, argumentTragetType);
+                    // 非基础类型的数据转换 ConvertUtils.convert 会返回原始类型不做转换
+                    if (tv.getClass() == argumentRowValue.getClass()) {
+                        tv = JSON.parseObject(JSON.toJSONString(argumentRowValue), argumentTragetType);
+                    }
                 } catch (Exception e) {
                     throw new IllegalArgumentException("convert argument failed!", e);
                 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/App.java
@@ -11,7 +11,7 @@ public class App {
 
     public static void main(String[] args) {
         Solon.start(App.class, args, app -> {
-            app.enableWebSocket(false);
+            app.enableWebSocket(true);
         });
     }
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/book/component/BookService.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/book/component/BookService.java
@@ -2,6 +2,7 @@ package demo.book.component;
 
 import demo.book.dto.BookInputDTO;
 import graphql.solon.annotation.QueryMapping;
+import graphql.solon.constant.OperationType;
 import org.noear.solon.annotation.Component;
 import org.noear.solon.annotation.Param;
 
@@ -22,7 +23,12 @@ public class BookService {
     }
 
     @QueryMapping
-    public BookInputDTO bookById(@Param("id") String id) {
+    public BookInputDTO bookById(@Param String id) {
         return this.generateNewOne(id);
+    }
+
+    @QueryMapping(typeName = OperationType.MUTATION)
+    public BookInputDTO createBook(@Param BookInputDTO book) {
+        return book;
     }
 }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/dto/ProductPriceHistoryDTO.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/dto/ProductPriceHistoryDTO.java
@@ -1,5 +1,7 @@
 package demo.product.dto;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class ProductPriceHistoryDTO {

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/support/ProductService.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/demo/product/support/ProductService.java
@@ -1,10 +1,17 @@
 package demo.product.support;
 
 import demo.product.dto.ProductPriceHistoryDTO;
+import graphql.solon.annotation.QueryMapping;
+import graphql.solon.annotation.SchemaMapping;
 import graphql.solon.annotation.SubscriptionMapping;
 import java.util.Date;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+
+import graphql.solon.constant.OperationType;
+import graphql.solon.util.ConcurrentReferenceHashMap;
 import org.noear.solon.annotation.Component;
 import org.noear.solon.annotation.Param;
 import reactor.core.publisher.Flux;
@@ -17,6 +24,20 @@ import reactor.core.publisher.Flux;
 public class ProductService {
 
     private final Random rn = new Random();
+    private final Map<Long, ProductPriceHistoryDTO> database = new ConcurrentHashMap<>();
+
+    @QueryMapping(typeName = OperationType.MUTATION)
+    public ProductPriceHistoryDTO addProduct(@Param("product") ProductPriceHistoryDTO product) {
+        database.put(product.getId(), product);
+        System.out.println("==== 添加");
+        return product;
+    }
+
+    @QueryMapping(typeName = OperationType.MUTATION)
+    public ProductPriceHistoryDTO removeProduct(@Param Long productId) {
+        System.out.println("==== 删除");
+        return database.remove(productId);
+    }
 
     @SubscriptionMapping("notifyProductPriceChange")
     public Flux<ProductPriceHistoryDTO> notifyProductPriceChange(@Param Long productId) {
@@ -32,7 +53,7 @@ public class ProductService {
                 }
 
                 return new ProductPriceHistoryDTO(productId, new Date(),
-                    (int) (rn.nextInt(10) + 1 + productId));
+                        rn.nextInt(10) + 1);
             }));
 
     }

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/MutationAndSubscriptionTest.java
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/java/graphql/solon/test/MutationAndSubscriptionTest.java
@@ -1,0 +1,132 @@
+package graphql.solon.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.alibaba.fastjson.JSON;
+import demo.App;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.concurrent.TimeUnit;
+
+import demo.product.dto.ProductPriceHistoryDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.noear.java_websocket.client.SimpleWebSocketClient;
+import org.noear.snack.ONode;
+import org.noear.solon.core.util.ResourceUtil;
+import org.noear.solon.test.HttpTester;
+import org.noear.solon.test.SolonJUnit5Extension;
+import org.noear.solon.test.SolonTest;
+
+/**
+ * 测试修改和订阅
+ *
+ * @author lagnx
+ */
+@ExtendWith(SolonJUnit5Extension.class)
+@SolonTest(value = App.class)
+public class MutationAndSubscriptionTest extends HttpTester {
+
+    @Test
+    public void testAddMutation() throws IOException {
+        ProductPriceHistoryDTO product = new ProductPriceHistoryDTO(123L, new Date(), 999);
+        ONode oNode = addProduct(product);
+
+        // addProduct 指定义的 GraphQL 操作名称
+        assertThat(oNode.get("addProduct").isNull(), is(false));
+        assertThat(oNode.select("addProduct.id").getLong(), is(product.getId()));
+        assertThat(oNode.select("addProduct.price").getInt(), is(product.getPrice()));
+        assertThat(oNode.select("addProduct.startDate").getString(), is(product.getStartDate().toString()));
+    }
+
+    @Test
+    public void testRemoveMutation() throws IOException {
+        ProductPriceHistoryDTO product = new ProductPriceHistoryDTO(123L, new Date(), 999);
+        addProduct(product);
+        ONode oNode = removeProduct(product.getId());
+
+        assertThat(oNode.get("removeProduct").isNull(), is(false));
+        assertThat(oNode.select("removeProduct.id").getLong(), is(product.getId()));
+        assertThat(oNode.select("removeProduct.price").getInt(), is(product.getPrice()));
+        assertThat(oNode.select("removeProduct.startDate").getString(), is(product.getStartDate().toString()));
+    }
+
+    /**
+     * 订阅测试：未完成！会失败
+     */
+    /*@Test
+    public void testSubscription() throws IOException, InterruptedException {
+        ProductPriceHistoryDTO product = new ProductPriceHistoryDTO(123L, new Date(), 999);
+
+        ONode param = new ONode();
+        ONode variables = new ONode();
+        variables.set("productId", product.getId());
+        param.set("query",
+                ResourceUtil.getResourceAsString("/query/subscriptionProduct.gqls"));
+        param.set("variables", variables);
+        param.set("operationName", "testSubscription");
+        String json = param.toJson();
+
+        // socket
+        SimpleWebSocketClient client = new SimpleWebSocketClient("ws://127.0.0.1:8081/graphql") {
+            @Override
+            public void onMessage(String message) {
+                super.onMessage(message);
+                System.out.println("get a message: " + message);
+            }
+        };
+
+        client.connectBlocking(10, TimeUnit.SECONDS);
+        //定制心跳（可选）
+        //client.heartbeatHandler(new HeartbeatHandlerDefault());
+        //开始心跳 + 心跳时自动重连
+        client.heartbeat(20_000, true);
+
+        //发送测试
+        client.send(json);
+
+        //休息会儿
+        for(int i = 0; i < 100; i++) {
+            Thread.sleep(1000);
+            System.out.println("====");
+        }
+
+        //关闭（使用 release 会同时停止心跳及自动重连）
+        client.release();
+    }*/
+
+    private ONode addProduct(ProductPriceHistoryDTO product) throws IOException {
+        ONode param = new ONode();
+        ONode variables = new ONode();
+
+        variables.set("product", JSON.parseObject(JSON.toJSONString(product), LinkedHashMap.class));
+
+        param.set("query",
+                ResourceUtil.getResourceAsString("/query/mutationAddProduct.gqls"));
+        param.set("variables", variables);
+        param.set("operationName", "testAdd");  // 有多个操作时，需指定需要执行的哪一个操作
+        String json = param.toJson();
+
+        String content = path("/graphql").bodyJson(json).post();
+        return ONode.loadStr(content).get("data");
+    }
+
+    private ONode removeProduct(Long productId) throws IOException {
+        ONode param = new ONode();
+        ONode variables = new ONode();
+
+        variables.set("productId", productId);
+
+        param.set("query",
+                ResourceUtil.getResourceAsString("/query/mutationRemoveProduct.gqls"));
+        param.set("variables", variables);
+        param.set("operationName", "testRemove");
+        String json = param.toJson();
+
+        String content = path("/graphql").bodyJson(json).post();
+        return ONode.loadStr(content).get("data");
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/product.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/graphql/product.gqls
@@ -2,7 +2,18 @@ extend type Subscription {
     notifyProductPriceChange (productId: ID): ProductPriceHistory
 }
 
+extend type Mutation {
+    addProduct(product: ProductInput!): ProductPriceHistory
+    removeProduct(productId: ID!): ProductPriceHistory
+}
+
 type ProductPriceHistory {
+    id: ID!
+    price: Int!
+    startDate: String!
+}
+
+input ProductInput {
     id: ID!
     price: Int!
     startDate: String!

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/mutationAddProduct.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/mutationAddProduct.gqls
@@ -1,0 +1,7 @@
+mutation testAdd ($product: ProductInput!){
+  addProduct(product: $product) {
+    id
+    price
+    startDate
+  }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/mutationRemoveProduct.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/mutationRemoveProduct.gqls
@@ -1,0 +1,7 @@
+mutation testRemove ($productId: ID!) {
+    removeProduct(productId: $productId) {
+        id
+        price
+        startDate
+    }
+}

--- a/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/subscriptionProduct.gqls
+++ b/solon-integration-projects/solon-plugin/graphql-solon-plugin/src/test/resources/query/subscriptionProduct.gqls
@@ -1,0 +1,5 @@
+subscription testSubscription($productId: ID!){
+  notifyProductPriceChange(productId: $productId) {
+    price
+  }
+}


### PR DESCRIPTION
- 传入JSON现在可以正确的转化为目标实体对象了
- 解决获取参数为空问题 #3 
- 添加 GraphQL Mutation 类型的请求测试
- 添加常量类 OperationType 用以定义 "Query" 、"Mutation" 和 "Subscription" 三种请求操作类型